### PR TITLE
Fix rendering of Unit 13 notes on website

### DIFF
--- a/docs/13-lsp.md
+++ b/docs/13-lsp.md
@@ -1,6 +1,7 @@
 # Unit 13: Liskov Substitution Principle
 
 After this unit, the student should:
+
 - understand the type of bugs that reckless developers can introduce when using inheritance and polymorphism
 - understand the Liskov Substitution Principle and thus be aware that not all IS-A relationship should be modeled with inheritance
 - know how to explicitly disallow inheritance when writing a class or disallow overriding with the `final` keyword


### PR DESCRIPTION
It appears that a newline must be added before the start of the list to get it recognized as a markdown list by mkdocs.

On the website now:
![image](https://user-images.githubusercontent.com/813865/105627861-43b3b480-5e74-11eb-8d52-aac0755f0824.png)
