### PR TITLE
Fix typo: Change `be` to `have`

### DIFF
--- a/docs/15-interface.md
+++ b/docs/15-interface.md
@@ -104,7 +104,7 @@ Note:
 
 ## Interface as Supertype
 
-If a class $C$ implements an interface $I$, $C <: I$.   This definition implies that a type can be multiple supertypes.  
+If a class $C$ implements an interface $I$, $C <: I$.   This definition implies that a type can have multiple supertypes.
 
 In the example above, `Flat` <: `GetAreable` and `Flat` <: `RealEstate`.
 


### PR DESCRIPTION
From the preceding and next line, this is what I inferred was the correct term. Do let me know if this is wrong.